### PR TITLE
Enhancement suggestion for the branch sdk_501

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, install the npm package and link it to your Android and iOS projects with
 1. Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
 2. In the `Downloading the SDK` section of the official integration guide:
 - If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow the integration guide
-- If you manual download the Line SDK ( according the sub section `Download from the "Downloads" page` ), before linking the SDK via Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
+- If you manual download the Line SDK ( according the sub section `Download from the "Downloads" page` ), before linking the SDK files via Xcode, be sure place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
 
 ### Android Setup
 1. Follow all the configuration steps in [LINE Login Android integration guide](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ First, install the npm package and link it to your Android and iOS projects with
 ```
 ### iOS Setup
 1. Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
-2. In `Downloading the SDK` section of the official integration guide:
-- If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow all of the 
-- If you download the Line SDK by manual download ( in the sub section `Download from the "Downloads" page` ), before linking the SDK via Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
+2. In the `Downloading the SDK` section of the official integration guide:
+- If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow the integration guide
+- If you manual download the Line SDK ( according the sub section `Download from the "Downloads" page` ), before linking the SDK via Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
 
 ### Android Setup
 1. Follow all the configuration steps in [LINE Login Android integration guide](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ First, install the npm package and link it to your Android and iOS projects with
   react-native link react-native-line-sdk
 ```
 ### iOS Setup
-Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
+1. Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
+2. In `Downloading the SDK` section of the official integration guide:
+- If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow all of the 
+- If you download the Line SDK by manual download ( in the sub section `Download from the "Downloads" page` ), before continue to do anything with Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
 
 ### Android Setup
 1. Follow all the configuration steps in [LINE Login Android integration guide](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, install the npm package and link it to your Android and iOS projects with
 1. Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
 2. In `Downloading the SDK` section of the official integration guide:
 - If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow all of the 
-- If you download the Line SDK by manual download ( in the sub section `Download from the "Downloads" page` ), before continue to do anything with Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
+- If you download the Line SDK by manual download ( in the sub section `Download from the "Downloads" page` ), before linking the SDK via Xcode, you should place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
 
 ### Android Setup
 1. Follow all the configuration steps in [LINE Login Android integration guide](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, install the npm package and link it to your Android and iOS projects with
 1. Follow all the configuration steps in [LINE Login iOS integration guide](https://developers.line.biz/en/docs/ios-sdk/objective-c/setting-up-project/)
 2. In the `Downloading the SDK` section of the official integration guide:
 - If you download the Line SDK via Cocoapods, this npm package should be integrated fine after you follow the integration guide
-- If you manual download the Line SDK ( according the sub section `Download from the "Downloads" page` ), before linking the SDK files via Xcode, be sure place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
+- If you manually download the Line SDK ( according the sub section `Download from the "Downloads" page` ), before linking the SDK files via Xcode, be sure place the SDK files `LineSDKResource.bundle` and `LineSDK.framework` inside the folder path `${YOUR_RN_PROJECT}/ios/Frameworks`
 
 ### Android Setup
 1. Follow all the configuration steps in [LINE Login Android integration guide](https://developers.line.biz/en/docs/android-sdk/integrate-line-login/)

--- a/ios/LineLoginManager.xcodeproj/project.pbxproj
+++ b/ios/LineLoginManager.xcodeproj/project.pbxproj
@@ -199,7 +199,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../../ios/Frameworks",
-					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/Frameworks",
+					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/LineSDK",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -220,7 +220,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/../../../ios/Frameworks",
-					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/Frameworks",
+					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/LineSDK",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/LineLoginManager.xcodeproj/project.pbxproj
+++ b/ios/LineLoginManager.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -196,7 +197,10 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../../../ios/Frameworks",
+					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -214,7 +218,10 @@
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../../../ios/Frameworks",
+					"$(PROJECT_DIR)/../../../ios/Pods/LineSDK/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,


### PR DESCRIPTION
Hello elmotan95,

Thank you for the impressive solution on the branch sdk_501, which provided a great help when we implement the Line login related feature on our product. 

We would like propose this enhancement PR to you for the following problems when we attempted integrate the solution with iOS.
* The the compile error  ['LineSDK/LineSDK.h' file not found](https://github.com/xmartlabs/react-native-line/issues/17) happened when we imported the LineSDK via Cocoapods
  * It probably caused by the incomplete `.podspec` file managed by Line
  * In this case, we can make it successfully compile by modify project.pbxproj file
* If we manually download the LineSDK related files, we can get the compile success only when we place the files in the static folder of the path `${RN_PROJECT}/ios/Frameworks`
  * In this PR, we suggest the enhanced description on the readme file, in order to help the other developer so they can clearly know where they should manually place the SDK files before continue to do anything with XCode.

Please feel free to let us know if you have any problem/question/concern remain, looking forward to hear from you soon.

Best wishes,
